### PR TITLE
Bump base image to 0.1.9

### DIFF
--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -1,6 +1,6 @@
 # Use osixia/light-baseimage
 # sources: https://github.com/osixia/docker-light-baseimage
-FROM osixia/light-baseimage:alpine-0.1.6-dev
+FROM osixia/light-baseimage:alpine-0.1.9
 
 # Keepalived version
 ARG KEEPALIVED_VERSION=2.0.20


### PR DESCRIPTION
The alpine 0.1.6-dev image does not appear to work correctly when
building on arm. Updating to 0.1.9 seems to have resolved the issue.

Fixes #35
May also be related to failures in #42