### PR TITLE
Fix wrong path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ This image require the kernel module ip_vs loaded on the host (`modprobe ip_vs`)
 This image comes with a keepalived config file that can be easily customized via environment variables for a quick bootstrap,
 but setting your own keepalived.conf is possible. 2 options:
 
-- Link your config file at run time to `/container/service/keepalived/assets/keepalived.conf` :
+- Link your config file at run time to `/usr/local/etc/keepalived/keepalived.conf` :
 
-      docker run --volume /data/my-keepalived.conf:/container/service/keepalived/assets/keepalived.conf --detach osixia/keepalived:2.0.20
+      docker run --volume /data/my-keepalived.conf:/usr/local/etc/keepalived/keepalived.conf --detach osixia/keepalived:2.0.20
 
 - Add your config file by extending or cloning this image, please refer to the [Advanced User Guide](#advanced-user-guide)
 


### PR DESCRIPTION
Because of `sed -i` inplace updates at start, file could not be mounted at this path